### PR TITLE
Proposition d'un terme plus explicite

### DIFF
--- a/fr-FR/fulfillment_request.txt
+++ b/fr-FR/fulfillment_request.txt
@@ -1,6 +1,6 @@
 <p>{{ service_name }},</p>
 <br>
-<p>Veuillez exécuter la commande {{ name }}.</p>
+<p>Veuillez réaliser la commande {{ name }}.</p>
 <p>Nombre d'articles: {{ fulfillment.item_count }}</p>
 <p>Articles uniques: {{ fulfillment.fulfillment_line_items.size }}</p>
 <br>


### PR DESCRIPTION
Je te propose d'utiliser le terme "Réaliser une commande" plutôt que "Exécuter une commande".